### PR TITLE
Bugfix in import for Python >= 3.10

### DIFF
--- a/nfnets/agc.py
+++ b/nfnets/agc.py
@@ -2,7 +2,7 @@ import torch
 from torch import nn, optim
 
 from nfnets.utils import unitwise_norm
-from collections import Iterable
+from collections.abc import Iterable
 
 
 class AGC(optim.Optimizer):


### PR DESCRIPTION
Howdy :)

Python 3.10+ collections library does not have the Iterable abstract class; it was moved to collections.abc. I propose a simple solution to this :)