### PR TITLE
Bugfix for Python > 3.10

### DIFF
--- a/nfnets/agc.py
+++ b/nfnets/agc.py
@@ -2,7 +2,7 @@ import torch
 from torch import nn, optim
 
 from nfnets.utils import unitwise_norm
-from collections import Iterable
+from collections.abc import Iterable
 
 
 class AGC(optim.Optimizer):


### PR DESCRIPTION
We import Iterable from Python's collections library, but this was moved to collections.abc